### PR TITLE
add fetch (subscribe) to the user data in Noticias and Catalogo

### DIFF
--- a/src/actions/member.js
+++ b/src/actions/member.js
@@ -88,16 +88,15 @@ export function getUser(dispatch) {
     return () => new Promise(resolve => resolve());
   }
 
-  const ref = FirebaseRef.child(`users/${UID}`);
+  return dispatch => new Promise(resolve => FirebaseRef.child(`users/${UID}`)
+    .on('value', (snapshot) => {
+      const userData = snapshot.val() || [];
 
-  return ref.on('value', (snapshot) => {
-    const userData = snapshot.val() || [];
-
-    return dispatch({
-      type: 'USER_DETAILS_UPDATE',
-      data: userData,
-    });
-  });
+      return dispatch({
+        type: 'USER_DETAILS_UPDATE',
+        data: userData,
+      });
+    })).catch(e => console.log(e));
 }
 
 /**

--- a/src/actions/member.js
+++ b/src/actions/member.js
@@ -73,6 +73,34 @@ function getUserData(dispatch) {
 }
 
 /**
+  * Get this User's Details
+  */
+export function getUser(dispatch) {
+  const UID = (
+    FirebaseRef
+    && Firebase
+    && Firebase.auth()
+    && Firebase.auth().currentUser
+    && Firebase.auth().currentUser.uid
+  ) ? Firebase.auth().currentUser.uid : null;
+
+  if (!UID) {
+    return () => new Promise(resolve => resolve());
+  }
+
+  const ref = FirebaseRef.child(`users/${UID}`);
+
+  return ref.on('value', (snapshot) => {
+    const userData = snapshot.val() || [];
+
+    return dispatch({
+      type: 'USER_DETAILS_UPDATE',
+      data: userData,
+    });
+  });
+}
+
+/**
   * Login to Firebase with Email/Password
   */
 export function login(formData) {

--- a/src/containers/CatalogosContainer.js
+++ b/src/containers/CatalogosContainer.js
@@ -21,7 +21,7 @@ class CatalogosContainer extends Component {
   }
 
   componentDidMount = () => {
-    this.fetchCatalogos();
+    this.fetchUser();
   }
 
   fetchUser = () => {

--- a/src/containers/CatalogosContainer.js
+++ b/src/containers/CatalogosContainer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { getCatalogos, setError } from '../actions/catalogosActions';
+import { getUser} from '../actions/member';
 import { updateCountdown } from '../actions/catalogosActions';
 
 class CatalogosContainer extends Component {
@@ -14,11 +15,23 @@ class CatalogosContainer extends Component {
       activeCatalogo: PropTypes.object.isRequired,
       pastCatalogos: PropTypes.array.isRequired,
     }).isRequired,
+    getUser: PropTypes.func.isRequired,
     getCatalogos: PropTypes.func.isRequired,
     setError: PropTypes.func.isRequired,
   }
 
-  componentDidMount = () => this.fetchCatalogos();
+  componentDidMount = () => {
+    this.fetchCatalogos();
+  }
+
+  fetchUser = () => {
+    return this.props.getUser()
+      .then(() => this.fetchCatalogos())
+      .catch((err) => {
+        console.log(`Error: ${err}`);
+        return this.props.setError(err);
+      });
+  }
 
   /**
     * Fetch Data from API, saving to Redux
@@ -54,6 +67,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
+  getUser,
   getCatalogos,
   setError,
   updateCountdown,

--- a/src/containers/NoticiasContainer.js
+++ b/src/containers/NoticiasContainer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { getNoticias, setError } from '../actions/noticiasActions';
+import { getUser } from '../actions/member';
 
 class NoticiasContainer extends Component {
   static propTypes = {
@@ -12,11 +13,24 @@ class NoticiasContainer extends Component {
       error: PropTypes.string,
       noticias: PropTypes.array.isRequired,
     }).isRequired,
+    getUser: PropTypes.func.isRequired,
     getNoticias: PropTypes.func.isRequired,
     setError: PropTypes.func.isRequired,
   }
 
-  componentDidMount = () => this.fetchNoticias();
+  componentDidMount = () => {
+    this.fetchUser();
+    //this.fetchNoticias();
+  }
+
+  fetchUser = () => {
+    return this.props.getUser()
+      .then(() => this.fetchNoticias())
+      .catch((err) => {
+        console.log(`Error: ${err}`);
+        return this.props.setError(err);
+      });
+  }
 
   /**
     * Fetch Data from API, saving to Redux
@@ -49,6 +63,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
+  getUser,
   getNoticias,
   setError,
 };


### PR DESCRIPTION
Subscribing to the user data updates was only happening on Login, so if the user never logged out and logged in again the app wouldn't receive updates on the user data (eg. token updates and collection). For now I only implemented it on Noticias and Catalogo, visiting either of those views would keep the app subscribed to the user data.