### PR TITLE
Feat sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "redux": "^3.7.2",
     "redux-persist": "^5.4.0",
     "redux-thunk": "^2.2.0",
+    "sentry-expo": "^1.7.0",
     "superagent": "^3.8.1"
   }
 }

--- a/src/actions/lotesActions.js
+++ b/src/actions/lotesActions.js
@@ -1,6 +1,7 @@
 import { Firebase, FirebaseRef } from '../lib/firebase';
 import { CloudFunctionsUrl } from '../constants/functions';
 import axios from 'axios';
+import Sentry from 'sentry-expo';
 
 import { showNotification } from './toastActions';
 
@@ -39,6 +40,10 @@ export function getLotes() {
           data: lotes,
           activeLotes, // pass activeLotes to loteReducer as action.activeLotes
         }));
-      })).catch(e => console.log(e));
+      })).catch(e => {
+        console.log(e);
+        // capture the exception
+        Sentry.captureException(new Error(e));
+      });
   }
 }

--- a/src/actions/member.js
+++ b/src/actions/member.js
@@ -5,6 +5,7 @@ import { Firebase, FirebaseRef } from '../lib/firebase';
 import { Actions } from 'react-native-router-flux';
 import _omitBy from 'lodash/omitBy';
 import _isNil from 'lodash/isNil';
+import Sentry from 'sentry-expo';
 
 /**
   * Sign Up to Firebase
@@ -43,7 +44,13 @@ export function signUp(formData) {
           }).then(() => statusMessage(dispatch, 'loading', false).then(resolve));
         }
       }).catch(reject);
-  }).catch(async (err) => { await statusMessage(dispatch, 'error', err.message); throw err.message; });
+  }).catch(async (err) => {
+
+    // capture the exception
+    Sentry.captureException(new Error(error));
+
+    await statusMessage(dispatch, 'error', err.message); throw err.message;
+  });
 }
 
 /**
@@ -64,6 +71,14 @@ function getUserData(dispatch) {
 
   return ref.on('value', (snapshot) => {
     const userData = snapshot.val() || [];
+
+    // Set the user context in Sentry
+    Sentry.setUserContext({
+      email: userData.email,
+      displayName: userData.displayName,
+      role: userData.role,
+      tokens: userData.tokens,
+    });
 
     return dispatch({
       type: 'USER_DETAILS_UPDATE',
@@ -92,11 +107,25 @@ export function getUser(dispatch) {
     .on('value', (snapshot) => {
       const userData = snapshot.val() || [];
 
+      // Set the user context in Sentry
+      Sentry.setUserContext({
+        email: userData.email,
+        displayName: userData.displayName,
+        role: userData.role,
+        tokens: userData.tokens,
+      });
+
       return dispatch({
         type: 'USER_DETAILS_UPDATE',
         data: userData,
       });
-    })).catch(e => console.log(e));
+    }))
+    .catch(error => {
+      console.log(error);
+
+      // capture the exception
+      Sentry.captureException(new Error(error));
+    });
 }
 
 /**
@@ -288,6 +317,8 @@ export function addToWishlist(addedLote) {
       .then(showNotification(dispatch, 'Añadida a tu lista de Deseos'))
       .catch((e) => {
         console.log(e);
+        // capture the exception
+        Sentry.captureException(new Error(e));
       });
   }
 }
@@ -331,6 +362,8 @@ export function removeFromWishlist(removedLote) {
       .then(showNotification(dispatch, 'Eliminada de tu lista de Deseos'))
       .catch((e) => {
         console.log(e);
+        // capture the exception
+        Sentry.captureException(new Error(e));
       });
   }
 

--- a/src/actions/noticiasActions.js
+++ b/src/actions/noticiasActions.js
@@ -1,4 +1,5 @@
 import { Firebase, FirebaseRef } from '../lib/firebase';
+import Sentry from 'sentry-expo';
 
 /**
  * Set an Error Message
@@ -26,5 +27,9 @@ export function getNoticias() {
         type: 'NOTICIAS_REPLACE',
         data: noticias,
       }));
-    })).catch(e => console.log(e));
+    })).catch(e => {
+      console.log(e);
+      // capture the exception
+      Sentry.captureException(new Error(e));
+    });
 }

--- a/src/actions/obrasActions.js
+++ b/src/actions/obrasActions.js
@@ -1,4 +1,5 @@
 import { Firebase, FirebaseRef } from '../lib/firebase';
+import Sentry from 'sentry-expo';
 
 /**
  * Set an Error Message
@@ -28,6 +29,10 @@ export function getObras() {
           type: 'OBRAS_REPLACE',
           data: obras,
         }));
-      })).catch(e => console.log(e));
+      })).catch(e => {
+        console.log(e);
+        // capture the exception
+        Sentry.captureException(new Error(e));
+      });
   }
 }

--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -1,0 +1,9 @@
+// Cloud functions url for dev
+let SentryDSN = 'https://128ef386e082446fb63706d298267c96@sentry.io/1185630';
+
+// Cloud functions url for prod
+if (Expo.Constants.manifest.releaseChannel === 'prod-v1') {
+  SentryDSN = 'https://afbb40e52cde4bb1b3fb528db95e9ff6@sentry.io/1141255'
+}
+
+export default SentryDSN;

--- a/src/native/components/BuyButton.js
+++ b/src/native/components/BuyButton.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { Firebase, FirebaseRef } from '../../lib/firebase';
 import axios from 'axios';
 import { Actions } from 'react-native-router-flux';
+import Sentry from 'sentry-expo';
 
 import { showNotification } from '../../actions/toastActions';
 import { throwConfetti } from '../../actions/confettiActions';
@@ -99,8 +100,6 @@ class BuyButton extends React.Component {
           } else {
             showNotification('¡Has adquirido estas obras!');
           }
-
-          // TODO show confetti
         }
       })
 
@@ -151,10 +150,17 @@ class BuyButton extends React.Component {
 
         console.log(error.config);
 
+        // capture the exception
+        Sentry.captureException(new Error(error));
+
       })
 
-      .catch(e => {
-        console.log(e);
+      .catch(error => {
+        console.log(error);
+
+        // capture the exception
+        Sentry.captureException(new Error(error));
+
 
         showNotification('Ha sucedido un error');
         this.resetButton();

--- a/src/native/index.js
+++ b/src/native/index.js
@@ -4,10 +4,12 @@ import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { Router } from 'react-native-router-flux';
 import { PersistGate } from 'redux-persist/es/integration/react';
+import Sentry from 'sentry-expo';
 
 import { StyleProvider } from 'native-base';
 import getTheme from '../../native-base-theme/components';
 import theme from '../../native-base-theme/variables/commonColor';
+import SentryDSN  from '../lib/sentry';
 
 import Routes from './routes/index';
 import Loading from './components/Loading';
@@ -17,6 +19,9 @@ console.disableYellowBox = true;
 // Hide StatusBar on Android as it overlaps tabs
 if (Platform.OS === 'android') StatusBar.setHidden(true);
 
+// Seup Sentry, for error logging
+Sentry.enableInExpoDevelopment = true; // https://docs.expo.io/versions/latest/guides/using-sentry.html#disabled-by-default-in-dev
+Sentry.config(SentryDSN).install();
 
 class Root extends Component {
   render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,12 +98,19 @@
   dependencies:
     cross-spawn "^5.1.0"
 
-"@expo/vector-icons@^6.1.0", "@expo/vector-icons@^6.2.2":
+"@expo/vector-icons@^6.1.0":
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-6.2.2.tgz#441edb58a52c0f4e5b4aba1e6f8da1e87cea7e11"
   dependencies:
     lodash "^4.17.4"
     react-native-vector-icons "4.4.2"
+
+"@expo/vector-icons@^6.2.2":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-6.3.1.tgz#ffb97cc2343e4a330b44ce3063ee7c8571a6a50d"
+  dependencies:
+    lodash "^4.17.4"
+    react-native-vector-icons "4.5.0"
 
 "@firebase/app-types@0.1.1":
   version "0.1.1"
@@ -4749,7 +4756,7 @@ inquirer@3.0.6:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
-inquirer@^3.0.1, inquirer@^3.0.6:
+inquirer@^3.0.1, inquirer@^3.0.6, inquirer@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
@@ -7556,7 +7563,7 @@ process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
 
-progress@^2.0.0:
+progress@2.0.0, progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
@@ -7720,6 +7727,10 @@ range-parser@~1.0.3:
 raven-js@^3.17.0:
   version "3.22.1"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.22.1.tgz#1117f00dfefaa427ef6e1a7d50bbb1fb998a24da"
+
+raven-js@^3.19.1:
+  version "3.24.1"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.24.1.tgz#7327e08786248517eedd36205bf50f1047821ffa"
 
 raven@^2.1.1:
   version "2.3.0"
@@ -7922,6 +7933,17 @@ react-native-scripts@1.7.0:
     rimraf "^2.6.1"
     xdl "46.0.1"
 
+react-native-sentry@^0.30.0:
+  version "0.30.3"
+  resolved "https://registry.yarnpkg.com/react-native-sentry/-/react-native-sentry-0.30.3.tgz#b64e59127070521aac51724235543e89def5ee73"
+  dependencies:
+    chalk "^2.3.0"
+    glob "^7.1.1"
+    inquirer "^3.3.0"
+    raven-js "^3.19.1"
+    sentry-cli-binary "^1.21.0"
+    xcode "^1.0.0"
+
 react-native-svg@5.4.2:
   version "5.4.2"
   resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-5.4.2.tgz#a01b4d88cda4b8ef4b2bc1adf05e11ec93a77b79"
@@ -7942,6 +7964,14 @@ react-native-thumbnail-video@^0.0.8:
 react-native-vector-icons@4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.4.2.tgz#090f42ee0396c4cc4eae0ddaa518028ba8df40c7"
+  dependencies:
+    lodash "^4.0.0"
+    prop-types "^15.5.10"
+    yargs "^8.0.2"
+
+react-native-vector-icons@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.5.0.tgz#6b95619e64f62f05f579f74a01fe5640df95158b"
   dependencies:
     lodash "^4.0.0"
     prop-types "^15.5.10"
@@ -8733,6 +8763,21 @@ sentence-case@^1.1.1, sentence-case@^1.1.2:
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-1.1.3.tgz#8034aafc2145772d3abe1509aa42c9e1042dc139"
   dependencies:
     lower-case "^1.1.1"
+
+sentry-cli-binary@^1.21.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/sentry-cli-binary/-/sentry-cli-binary-1.25.0.tgz#61d11b019712b5b1075e488731d6960b28959183"
+  dependencies:
+    progress "2.0.0"
+
+sentry-expo@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/sentry-expo/-/sentry-expo-1.7.0.tgz#060b40146601672eed48c1ba75afbbdfe7b822c6"
+  dependencies:
+    "@expo/spawn-async" "^1.2.8"
+    mkdirp "^0.5.1"
+    react-native-sentry "^0.30.0"
+    rimraf "^2.6.1"
 
 sequencify@~0.0.7:
   version "0.0.7"
@@ -10210,6 +10255,14 @@ ws@^2.0.3:
 xcode@^0.9.1:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/xcode/-/xcode-0.9.3.tgz#910a89c16aee6cc0b42ca805a6d0b4cf87211cf3"
+  dependencies:
+    pegjs "^0.10.0"
+    simple-plist "^0.2.1"
+    uuid "3.0.1"
+
+xcode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-1.0.0.tgz#e1f5b1443245ded38c180796df1a10fdeda084ec"
   dependencies:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"


### PR DESCRIPTION
This integrates Sentry which is:

> Open-source error tracking that helps developers monitor and fix crashes in real time. Iterate continuously. Boost efficiency. Improve user experience.

Basically if the app crashes or errors out Sentry catches it and reports it with a stack trace. I've also added catching of some errors manually which don't crash the app or `throw` error but it's good we log them. 

There's a part that sets the user data to sentry so we know what errors happened to who.

This is what the **exact** error we had on Thursday would look like
![sentry io_interglobal-vision_dev-adaimaje-co_issues_522456417__query is_unresolved](https://user-images.githubusercontent.com/1994425/38529739-668ec35e-3c2c-11e8-9e50-8a0e3009ac58.png)

Sentry login is in a card in the board.