### PR TITLE
Patch: Remove wishlist Lote back button override

### DIFF
--- a/src/native/components/wishlist/WishlistItem.js
+++ b/src/native/components/wishlist/WishlistItem.js
@@ -44,10 +44,7 @@ export default class WishlistItem extends Component {
         params: {
           id: String(item.id)
         }
-      },
-      onBack: () => {
-        Actions.wishlist();
-      },
+      }
     });
 
     return (


### PR DESCRIPTION
Therefore when wishlist items are clicked now take the user to the Lote as if they came from the Catalog. Not perfect UX but without a unescapable nav loop.